### PR TITLE
[12] Initialize React Architecture & Environment

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Global Earthquake Monitor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "global-earthquake-monitor",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0",
+    "@tanstack/react-query": "^5.17.0",
+    "zustand": "^4.4.7",
+    "recharts": "^2.10.0",
+    "react-leaflet": "^4.2.1",
+    "leaflet": "^1.9.4",
+    "axios": "^1.6.5"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "@types/leaflet": "^1.9.8",
+    "@types/node": "^20.11.5",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.12"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,57 @@
+import { Routes, Route, NavLink } from 'react-router-dom'
+import FilterSidebar from './components/layout/FilterSidebar'
+
+const tabs = [
+  { label: 'Analytics', to: '/' },
+  { label: 'Map', to: '/map' },
+  { label: 'Timeline', to: '/timeline' },
+  { label: 'Time Series', to: '/timeseries' },
+  { label: 'Chat', to: '/chat' },
+]
+
+function Placeholder({ name }: { name: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-gray-400 text-xl">
+      {name} — coming soon
+    </div>
+  )
+}
+
+export default function App() {
+  return (
+    <div className="flex h-screen bg-gray-900 text-white overflow-hidden">
+      <FilterSidebar />
+      <div className="flex flex-col flex-1 overflow-hidden">
+        {/* Top nav */}
+        <nav className="bg-gray-800 border-b border-gray-700 flex gap-1 px-4 py-2 shrink-0">
+          {tabs.map((tab) => (
+            <NavLink
+              key={tab.to}
+              to={tab.to}
+              end={tab.to === '/'}
+              className={({ isActive }) =>
+                `px-4 py-2 rounded text-sm font-medium transition-colors ${
+                  isActive
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-300 hover:bg-gray-700 hover:text-white'
+                }`
+              }
+            >
+              {tab.label}
+            </NavLink>
+          ))}
+        </nav>
+        {/* Main content */}
+        <main className="flex-1 overflow-auto p-4">
+          <Routes>
+            <Route path="/" element={<Placeholder name="Analytics" />} />
+            <Route path="/map" element={<Placeholder name="Map" />} />
+            <Route path="/timeline" element={<Placeholder name="Timeline" />} />
+            <Route path="/timeseries" element={<Placeholder name="Time Series" />} />
+            <Route path="/chat" element={<Placeholder name="Chat" />} />
+          </Routes>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/FilterSidebar.tsx
+++ b/frontend/src/components/layout/FilterSidebar.tsx
@@ -1,0 +1,8 @@
+export default function FilterSidebar() {
+  return (
+    <aside className="w-64 bg-gray-800 text-white flex flex-col p-4 shrink-0">
+      <h2 className="text-lg font-semibold mb-4">Filters</h2>
+      <p className="text-gray-400 text-sm">Filter controls coming soon.</p>
+    </aside>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+)

--- a/frontend/src/types/earthquake.ts
+++ b/frontend/src/types/earthquake.ts
@@ -1,0 +1,42 @@
+export interface EarthquakeEvent {
+  id: string
+  title: string
+  main_time: string
+  magnitude: number
+  magnitude_type: string
+  depth_km: number
+  latitude: number
+  longitude: number
+  place: string
+  country: string
+  alert_level: 'Green' | 'Yellow' | 'Orange' | 'Red' | 'Unknown'
+  tsunami: 0 | 1
+  felt: number | null
+  status: string
+  source: string
+  link: string
+  severity_text: string
+  population_text: string
+}
+
+export interface AlertBreakdown {
+  green: number
+  yellow: number
+  orange: number
+  red: number
+  unknown: number
+}
+
+export interface TopRegion {
+  region: string
+  count: number
+}
+
+export interface EarthquakeSummary {
+  total_count: number
+  average_magnitude: number
+  max_magnitude: number
+  tsunami_count: number
+  alert_breakdown: AlertBreakdown
+  top_regions: TopRegion[]
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- Scaffolds the React 18 + Vite + TypeScript frontend at `frontend/`
- App shell with 5-tab navigation (Analytics, Map, Timeline, Time Series, Chat) using React Router v6
- Sidebar layout with `FilterSidebar` placeholder
- TypeScript interfaces for `EarthquakeEvent` and `EarthquakeSummary` matching the backend schemas exactly
- Tailwind CSS, PostCSS, `vite.config.ts` with `/api` proxy to backend, `frontend/.env.example`

## Test plan
- [ ] `cd frontend && npm install && npm run build` completes without errors
- [ ] Dev server starts with `npm run dev` and all 5 tab routes render
- [ ] `.env.example` documents `VITE_API_URL`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)