### PR TITLE
fix: healthcheck path, country extraction, frontend API pagination and limits

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -45,6 +45,6 @@ RUN mkdir -p .cache/canonical && chmod -R 777 .cache
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:8000/api/v1/health || exit 1
+    CMD curl -f http://localhost:8000/health || exit 1
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -130,7 +130,7 @@ class Settings(BaseSettings):
         description="Default minimum magnitude for earthquake queries.",
     )
     XSLT_DIR: str = Field(
-        "transforms",
+        "../transforms",
         description=(
             "Path to the top-level transforms/ directory that contains the XSLT "
             "stylesheets used in the XML canonicalization pipeline."

--- a/backend/app/services/xml_pipeline.py
+++ b/backend/app/services/xml_pipeline.py
@@ -21,6 +21,41 @@ from app.schemas.earthquakes import EarthquakeEvent
 
 logger = logging.getLogger(__name__)
 
+_US_STATES = {
+    # Full names
+    "Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado",
+    "Connecticut", "Delaware", "Florida", "Georgia", "Hawaii", "Idaho",
+    "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana",
+    "Maine", "Maryland", "Massachusetts", "Michigan", "Minnesota",
+    "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada",
+    "New Hampshire", "New Jersey", "New Mexico", "New York",
+    "North Carolina", "North Dakota", "Ohio", "Oklahoma", "Oregon",
+    "Pennsylvania", "Rhode Island", "South Carolina", "South Dakota",
+    "Tennessee", "Texas", "Utah", "Vermont", "Virginia", "Washington",
+    "West Virginia", "Wisconsin", "Wyoming", "Puerto Rico", "Guam",
+    "Virgin Islands", "American Samoa", "Northern Mariana Islands",
+    # Abbreviations
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+    "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+    "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+    "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+    "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+    "PR", "GU", "VI", "AS", "MP",
+}
+
+
+def _extract_country(place: str) -> str:
+    """Derive country from a USGS place string like '20 km NE of City, Country'."""
+    if not place:
+        return "Unknown"
+    parts = place.split(",")
+    last = parts[-1].strip()
+    if not last:
+        return "Unknown"
+    if last in _US_STATES:
+        return "United States"
+    return last
+
 
 class XMLPipelineService:
     """End-to-end XML data pipeline: Raw -> XSLT -> Canonical -> JSON."""
@@ -111,6 +146,11 @@ class XMLPipelineService:
                     else:
                         alert = "Green"
 
+                place = get_val("place")
+                country = get_val("country", "Unknown")
+                if country == "Unknown":
+                    country = _extract_country(place)
+
                 events.append(EarthquakeEvent(
                     id=get_val("id"),
                     title=get_val("title"),
@@ -120,8 +160,8 @@ class XMLPipelineService:
                     depth_km=float(get_val("depth_km", "0.0")),
                     latitude=float(get_val("latitude", "0.0")),
                     longitude=float(get_val("longitude", "0.0")),
-                    place=get_val("place"),
-                    country=get_val("country", "Unknown"),
+                    place=place,
+                    country=country,
                     alert_level=alert,
                     alert_score=float(get_val("alert_score", "0.0")) or None,
                     tsunami=int(get_val("tsunami", "0")),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,14 +22,16 @@ services:
       - "8000:8000"
     volumes:
       - backend_cache:/app/.cache
+      - ./transforms:/app/transforms
     env_file:
       - ./backend/.env
     environment:
       - ENV=production
       - CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
+      - XSLT_DIR=transforms
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,6 +16,13 @@ export interface EarthquakeParams {
   offset?: number
 }
 
+interface PaginatedResponse {
+  items: EarthquakeEvent[]
+  total: number
+  offset: number
+  limit: number
+}
+
 export async function fetchEarthquakes(params: EarthquakeParams): Promise<EarthquakeEvent[]> {
   const { alert_levels, countries, start_date, end_date, ...rest } = params
   const queryParams: Record<string, unknown> = { ...rest }
@@ -25,8 +32,8 @@ export async function fetchEarthquakes(params: EarthquakeParams): Promise<Earthq
   if (alert_levels && alert_levels.length > 0) queryParams['alert_levels[]'] = alert_levels
   if (countries && countries.length > 0) queryParams['countries[]'] = countries
 
-  const response = await api.get<EarthquakeEvent[]>('/api/v1/earthquakes', { params: queryParams })
-  return response.data
+  const response = await api.get<PaginatedResponse>('/api/v1/earthquakes', { params: queryParams })
+  return response.data.items
 }
 
 export async function fetchSummary(params: Omit<EarthquakeParams, 'limit' | 'offset'>): Promise<EarthquakeSummary> {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3,6 +3,19 @@ import type { EarthquakeEvent, EarthquakeSummary } from '../types/earthquake'
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL ?? '',
+  paramsSerializer: {
+    serialize: (params) => {
+      const sp = new URLSearchParams()
+      for (const [key, value] of Object.entries(params)) {
+        if (Array.isArray(value)) {
+          for (const v of value) sp.append(key, String(v))
+        } else if (value !== undefined && value !== null) {
+          sp.set(key, String(value))
+        }
+      }
+      return sp.toString()
+    },
+  },
 })
 
 export interface EarthquakeParams {
@@ -29,8 +42,8 @@ export async function fetchEarthquakes(params: EarthquakeParams): Promise<Earthq
 
   if (start_date) queryParams.start_date = start_date
   if (end_date) queryParams.end_date = end_date
-  if (alert_levels && alert_levels.length > 0) queryParams['alert_levels[]'] = alert_levels
-  if (countries && countries.length > 0) queryParams['countries[]'] = countries
+  if (alert_levels && alert_levels.length > 0) queryParams.alert_levels = alert_levels
+  if (countries && countries.length > 0) queryParams.countries = countries
 
   const response = await api.get<PaginatedResponse>('/api/v1/earthquakes', { params: queryParams })
   return response.data.items
@@ -42,8 +55,8 @@ export async function fetchSummary(params: Omit<EarthquakeParams, 'limit' | 'off
 
   if (start_date) queryParams.start_date = start_date
   if (end_date) queryParams.end_date = end_date
-  if (alert_levels && alert_levels.length > 0) queryParams['alert_levels[]'] = alert_levels
-  if (countries && countries.length > 0) queryParams['countries[]'] = countries
+  if (alert_levels && alert_levels.length > 0) queryParams.alert_levels = alert_levels
+  if (countries && countries.length > 0) queryParams.countries = countries
 
   const response = await api.get<EarthquakeSummary>('/api/v1/earthquakes/summary', { params: queryParams })
   return response.data

--- a/frontend/src/components/layout/FilterSidebar.tsx
+++ b/frontend/src/components/layout/FilterSidebar.tsx
@@ -3,6 +3,13 @@ import { useFilterStore, type FilterState } from '../../store/filterStore'
 
 const ALERT_LEVELS = ['Green', 'Yellow', 'Orange', 'Red']
 
+const COMMON_COUNTRIES = [
+  'United States', 'Japan', 'Indonesia', 'China', 'Turkey',
+  'Mexico', 'Italy', 'Greece', 'Chile', 'Peru',
+  'Iran', 'New Zealand', 'Philippines', 'India', 'Pakistan',
+  'Afghanistan', 'Nepal', 'Papua New Guinea', 'Tonga', 'Vanuatu',
+]
+
 export default function FilterSidebar() {
   const store = useFilterStore()
 
@@ -11,12 +18,24 @@ export default function FilterSidebar() {
   const [localEnd, setLocalEnd] = useState(store.endDate ?? '')
   const [localMag, setLocalMag] = useState(store.minMagnitude)
   const [localAlerts, setLocalAlerts] = useState<string[]>(store.alertLevels)
+  const [localCountries, setLocalCountries] = useState<string[]>(store.countries)
+  const [countrySearch, setCountrySearch] = useState('')
 
   function toggleAlert(level: string) {
     setLocalAlerts((prev) =>
       prev.includes(level) ? prev.filter((l) => l !== level) : [...prev, level]
     )
   }
+
+  function toggleCountry(country: string) {
+    setLocalCountries((prev) =>
+      prev.includes(country) ? prev.filter((c) => c !== country) : [...prev, country]
+    )
+  }
+
+  const filteredCountries = COMMON_COUNTRIES.filter((c) =>
+    c.toLowerCase().includes(countrySearch.toLowerCase())
+  )
 
   function applyFilters() {
     store.applyFilters({
@@ -25,6 +44,7 @@ export default function FilterSidebar() {
       endDate: localEnd || null,
       minMagnitude: localMag,
       alertLevels: localAlerts,
+      countries: localCountries,
     })
   }
 
@@ -87,7 +107,7 @@ export default function FilterSidebar() {
       </div>
 
       {/* Alert levels */}
-      <div className="mb-6">
+      <div className="mb-4">
         <label className="block text-xs text-gray-400 mb-2 uppercase tracking-wide">Alert Levels</label>
         {ALERT_LEVELS.map((level) => (
           <label key={level} className="flex items-center gap-2 mb-1 cursor-pointer">
@@ -100,6 +120,41 @@ export default function FilterSidebar() {
             <span className="text-sm">{level}</span>
           </label>
         ))}
+      </div>
+
+      {/* Country filter */}
+      <div className="mb-6">
+        <label className="block text-xs text-gray-400 mb-2 uppercase tracking-wide">
+          Countries {localCountries.length > 0 && <span className="text-blue-400">({localCountries.length})</span>}
+        </label>
+        <input
+          type="text"
+          value={countrySearch}
+          onChange={(e) => setCountrySearch(e.target.value)}
+          placeholder="Search countries..."
+          className="w-full bg-gray-700 text-white rounded px-2 py-1.5 text-xs border border-gray-600 focus:outline-none focus:border-blue-500 placeholder-gray-500 mb-2"
+        />
+        <div className="max-h-36 overflow-y-auto space-y-1 pr-1">
+          {filteredCountries.map((country) => (
+            <label key={country} className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={localCountries.includes(country)}
+                onChange={() => toggleCountry(country)}
+                className="accent-blue-500 shrink-0"
+              />
+              <span className="text-xs text-gray-300">{country}</span>
+            </label>
+          ))}
+        </div>
+        {localCountries.length > 0 && (
+          <button
+            onClick={() => setLocalCountries([])}
+            className="mt-2 text-xs text-gray-500 hover:text-red-400 transition-colors"
+          >
+            Clear countries
+          </button>
+        )}
       </div>
 
       <button

--- a/frontend/src/pages/AnalyticsPage.tsx
+++ b/frontend/src/pages/AnalyticsPage.tsx
@@ -58,7 +58,7 @@ const PAGE_SIZE = 20
 
 export default function AnalyticsPage() {
   const { data: summary, isLoading: summaryLoading, isError: summaryError } = useSummary()
-  const { data: events, isLoading: eventsLoading, isError: eventsError } = useEarthquakes(1000)
+  const { data: events, isLoading: eventsLoading, isError: eventsError } = useEarthquakes(500)
   const [searchQuery, setSearchQuery] = useState('')
   const [currentPage, setCurrentPage] = useState(0)
 

--- a/frontend/src/pages/MapPage.tsx
+++ b/frontend/src/pages/MapPage.tsx
@@ -19,7 +19,7 @@ const ALERT_COLORS: Record<string, string> = {
 }
 
 export default function MapPage() {
-  const { data: events, isLoading, isError } = useEarthquakes(2000)
+  const { data: events, isLoading, isError } = useEarthquakes(500)
 
   return (
     <div className="relative h-[calc(100vh-120px)]">

--- a/frontend/src/pages/TimeSeriesPage.tsx
+++ b/frontend/src/pages/TimeSeriesPage.tsx
@@ -47,7 +47,7 @@ function Spinner() {
 }
 
 export default function TimeSeriesPage() {
-  const { data: events, isLoading, isError } = useEarthquakes(2000)
+  const { data: events, isLoading, isError } = useEarthquakes(500)
 
   if (isLoading) return <Spinner />
   if (isError || !events) {

--- a/frontend/src/pages/TimelinePage.tsx
+++ b/frontend/src/pages/TimelinePage.tsx
@@ -22,7 +22,7 @@ const SPEEDS = [1, 5, 10] as const
 type Speed = (typeof SPEEDS)[number]
 
 export default function TimelinePage() {
-  const { data: events, isLoading, isError } = useEarthquakes(2000)
+  const { data: events, isLoading, isError } = useEarthquakes(500)
 
   const [currentTime, setCurrentTime] = useState<Date>(new Date())
   const [isPlaying, setIsPlaying] = useState(false)


### PR DESCRIPTION
## Summary
- Fix Docker healthcheck route and XSLT path resolution so the backend container reports healthy
- Extract country from USGS `place` string in the XML pipeline instead of hardcoding `Unknown`
- Unwrap the paginated API response on the frontend, fix array param serialization, and add a country filter
- Cap `useEarthquakes` at 500 on Map, TimeSeries, and Timeline pages to avoid 422 errors from oversized limits

## Test plan
- [ ] `docker compose up` and confirm backend healthcheck passes
- [ ] Verify earthquake records show a real country instead of `Unknown`
- [ ] Load Map, TimeSeries, Timeline, and Analytics pages — no 422 errors, data renders
- [ ] Apply the country filter in the sidebar and confirm results update