### PR TITLE
perf(backend): XSLT singleton, async HTTP, and in-memory TTL cache

### DIFF
--- a/backend/app/api/v1/chat.py
+++ b/backend/app/api/v1/chat.py
@@ -1,17 +1,8 @@
 """
 /api/v1/chat — AI-powered seismic chat endpoint.
 
-This router wraps the SeismicAI service (backed by Google Gemini) behind a
-single POST endpoint that accepts a user message plus optional conversation
-history, and returns a plain-text AI response.
-
-Full implementation is delivered in issue #10 (Port AI chat endpoint).
-
-Currently scaffolded endpoints
--------------------------------
 POST /api/v1/chat
     Accept a ChatRequest body (message + history) and return an AI response.
-    Streamed responses will be considered in issue #10.
 """
 
 from __future__ import annotations
@@ -20,7 +11,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from app.core.config import Settings
-from app.core.dependencies import get_settings
+from app.core.dependencies import get_pipeline, get_settings
 from app.schemas.chat import ChatRequest, ChatResponse, SuggestedAction as SuggestedActionSchema
 
 from app.services.xml_pipeline import XMLPipelineService
@@ -49,6 +40,7 @@ router = APIRouter()
 async def chat(
     body: ChatRequest,
     cfg: Settings = Depends(get_settings),
+    pipeline: XMLPipelineService = Depends(get_pipeline),
 ) -> ChatResponse:
     logger.info("POST /chat — message=%.80s", body.message)
 
@@ -59,10 +51,9 @@ async def chat(
         )
 
     # Fetch the dataset slice matching the frontend's view so the AI can be grounded
-    pipeline = XMLPipelineService(xslt_dir=cfg.XSLT_DIR, cache_dir=cfg.CACHE_DIR)
     source = body.source or "USGS"
     min_mag = body.min_magnitude if body.min_magnitude is not None else cfg.DEFAULT_MIN_MAGNITUDE
-    events = pipeline.get_earthquakes(
+    events = await pipeline.get_earthquakes(
         source=source, start_date=body.start_date, end_date=body.end_date, min_mag=min_mag
     )
 
@@ -76,7 +67,6 @@ async def chat(
     try:
         result = await ai.generate_chat_response(body.message, context, history)
     except QuotaExceeded as e:
-        # Quota problems map to 429 Too Many Requests
         raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(e))
     except PermanentAIError as e:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(e))

--- a/backend/app/api/v1/earthquakes.py
+++ b/backend/app/api/v1/earthquakes.py
@@ -3,10 +3,8 @@
 
 This router provides read-only endpoints for fetching, filtering, and
 summarising earthquake event data from the upstream USGS and GDACS
-providers. Full implementation is delivered in a later issue (#08).
+providers.
 
-Currently scaffolded endpoints
--------------------------------
 GET /api/v1/earthquakes
     Query earthquakes by date range, magnitude, source, and optional filters.
     Returns a paginated list of EarthquakeEvent models.
@@ -14,27 +12,24 @@ GET /api/v1/earthquakes
 GET /api/v1/earthquakes/summary
     Return aggregated summary statistics (count, avg/max magnitude, tsunami
     advisory count) for the current filter set.
-
-These handlers return placeholder 501 responses until the XML/XSLT
-pipeline (issue #06) and core REST endpoint logic (issue #08) are wired in.
 """
 
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Query
 
 from app.core.config import Settings
-from app.core.dependencies import get_settings
+from app.core.dependencies import get_pipeline, get_settings
 from app.schemas.earthquakes import EarthquakeListResponse, EarthquakeSummary
 from app.services.xml_pipeline import XMLPipelineService
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-pipeline = XMLPipelineService()
 
 # ---------------------------------------------------------------------------
 # Type aliases for reusable query param annotations
@@ -88,7 +83,7 @@ Search = Annotated[
         "where loading the full result into the browser would degrade render performance."
     ),
 )
-def list_earthquakes(
+async def list_earthquakes(
     start_date: StartDate = None,
     end_date: EndDate = None,
     min_magnitude: MinMagnitude = 2.5,
@@ -99,6 +94,7 @@ def list_earthquakes(
     alert_levels: list[str] | None = Query(None, description="Filter by alert level (repeatable): Green, Yellow, Orange, Red."),
     countries: list[str] | None = Query(None, description="Filter by country name (repeatable)."),
     cfg: Settings = Depends(get_settings),
+    pipeline: XMLPipelineService = Depends(get_pipeline),
 ) -> dict:
     logger.info(
         "GET /earthquakes — source=%s start=%s end=%s min_mag=%.1f limit=%d offset=%d",
@@ -110,7 +106,7 @@ def list_earthquakes(
     all_events = []
     for src in sources:
         all_events.extend(
-            pipeline.get_earthquakes(
+            await pipeline.get_earthquakes(
                 source=src,
                 start_date=start_date,
                 end_date=end_date,
@@ -163,17 +159,18 @@ def list_earthquakes(
         "tsunami advisory count) for the filtered earthquake dataset."
     ),
 )
-def earthquake_summary(
+async def earthquake_summary(
     start_date: StartDate = None,
     end_date: EndDate = None,
     min_magnitude: MinMagnitude = 2.5,
     source: DataSource = "USGS",
     cfg: Settings = Depends(get_settings),
+    pipeline: XMLPipelineService = Depends(get_pipeline),
 ) -> dict:
     logger.info("GET /earthquakes/summary — source=%s", source)
 
     # Fetch the full unfiltered page to compute accurate summary stats
-    response = list_earthquakes(
+    response = await list_earthquakes(
         start_date=start_date,
         end_date=end_date,
         min_magnitude=min_magnitude,
@@ -184,9 +181,10 @@ def earthquake_summary(
         alert_levels=None,
         countries=None,
         cfg=cfg,
+        pipeline=pipeline,
     )
     events = response["items"]
-    
+
     if not events:
         return {
             "total_count": 0,
@@ -199,7 +197,7 @@ def earthquake_summary(
 
     mags = [e.magnitude for e in events]
     tsunamis = sum(1 for e in events if e.tsunami == 1)
-    
+
     # Alert breakdown
     breakdown = {"green": 0, "yellow": 0, "orange": 0, "red": 0, "unknown": 0}
     for e in events:
@@ -209,8 +207,6 @@ def earthquake_summary(
         else:
             breakdown["unknown"] += 1
 
-    # Top regions (simplified counts)
-    from collections import Counter
     regions = Counter(e.country for e in events).most_common(5)
     top_regions = [{"region": r, "count": c} for r, c in regions]
 

--- a/backend/app/api/v1/export.py
+++ b/backend/app/api/v1/export.py
@@ -5,11 +5,6 @@ Provides structured data downloads in multiple formats. The XML export is
 a primary deliverable of the architecture: it must return the *canonicalized*
 XML (transformed via XSLT), not raw upstream XML.
 
-Full implementation is delivered in issue #11 (Port export/report routes).
-The XML pipeline itself lands in issue #06.
-
-Currently scaffolded endpoints
--------------------------------
 GET /api/v1/export/xml
     Return canonical XSLT-transformed earthquake XML for the current dataset.
 
@@ -22,18 +17,17 @@ GET /api/v1/export/pdf
 
 from __future__ import annotations
 
-import logging
-from typing import Annotated, Literal
-from datetime import datetime, timezone
-
 import io
+import logging
+from datetime import datetime, timezone
+from typing import Annotated, Literal
 
 import pandas as pd
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import Response
 
 from app.core.config import Settings
-from app.core.dependencies import get_settings
+from app.core.dependencies import get_pipeline, get_settings
 from app.services.pdf_report import generate_situation_report
 from app.services.xml_pipeline import XMLPipelineService
 
@@ -63,8 +57,7 @@ DataSource = Annotated[
         "Return XSLT-transformed canonical earthquake XML. "
         "This route must emit the *canonicalized* schema produced by the XSLT "
         "pipeline in transforms/, never the raw upstream QuakeML or RSS XML. "
-        "Fields map to the EarthquakeEvent JSON model. "
-        "Full implementation lands in issue #11 / pipeline wired in issue #06."
+        "Fields map to the EarthquakeEvent JSON model."
     ),
     responses={
         200: {
@@ -73,15 +66,15 @@ DataSource = Annotated[
         }
     },
 )
-def export_xml(
+async def export_xml(
     start_date: StartDate = None,
     end_date: EndDate = None,
     min_magnitude: MinMagnitude = 2.5,
     source: DataSource = "USGS",
     cfg: Settings = Depends(get_settings),
+    pipeline: XMLPipelineService = Depends(get_pipeline),
 ) -> Response:
     logger.info("GET /export/xml — source=%s", source)
-    pipeline = XMLPipelineService()
     params = {
         "starttime": start_date,
         "endtime": end_date,
@@ -89,13 +82,12 @@ def export_xml(
         "orderby": "time",
     }
     if source == "BOTH":
-        # Fetch both sources and concatenate their canonical XML event nodes
         from lxml import etree  # noqa: PLC0415
 
         root = etree.Element("EarthquakeDataset")
         for src in ("USGS", "GDACS"):
             try:
-                raw_xml = pipeline.fetch_raw_xml(src, dict(params))
+                raw_xml = await pipeline.fetch_raw_xml(src, dict(params))
                 canonical_xml = pipeline.apply_xslt(raw_xml, src)
                 src_root = etree.fromstring(canonical_xml.encode("utf-8"))
                 for node in src_root:
@@ -104,7 +96,7 @@ def export_xml(
                 logger.warning("XML fetch failed for source %s: %s", src, exc)
         canonical_bytes = etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="utf-8")
     else:
-        raw_xml = pipeline.fetch_raw_xml(source, params)
+        raw_xml = await pipeline.fetch_raw_xml(source, params)
         canonical_xml = pipeline.apply_xslt(raw_xml, source)
         canonical_bytes = canonical_xml.encode("utf-8")
 
@@ -123,21 +115,21 @@ def export_xml(
         }
     },
 )
-def export_csv(
+async def export_csv(
     start_date: StartDate = None,
     end_date: EndDate = None,
     min_magnitude: MinMagnitude = 2.5,
     source: DataSource = "USGS",
     cfg: Settings = Depends(get_settings),
+    pipeline: XMLPipelineService = Depends(get_pipeline),
 ) -> Response:
     logger.info("GET /export/csv — source=%s", source)
-    pipeline = XMLPipelineService()
     events: list = []
     if source == "BOTH":
-        events.extend(pipeline.get_earthquakes("USGS", start_date, end_date, min_magnitude))
-        events.extend(pipeline.get_earthquakes("GDACS", start_date, end_date, min_magnitude))
+        events.extend(await pipeline.get_earthquakes("USGS", start_date, end_date, min_magnitude))
+        events.extend(await pipeline.get_earthquakes("GDACS", start_date, end_date, min_magnitude))
     else:
-        events = pipeline.get_earthquakes(source, start_date, end_date, min_magnitude)
+        events = await pipeline.get_earthquakes(source, start_date, end_date, min_magnitude)
 
     rows = [e.model_dump() if hasattr(e, "model_dump") else e.dict() for e in events]
     df = pd.DataFrame(rows)
@@ -163,7 +155,7 @@ def export_csv(
         }
     },
 )
-def export_pdf(
+async def export_pdf(
     start_date: StartDate = None,
     end_date: EndDate = None,
     min_magnitude: MinMagnitude = 2.5,
@@ -171,6 +163,7 @@ def export_pdf(
     alerts: list[str] | None = Query(None, description="Filter by alert level; repeatable"),
     countries: list[str] | None = Query(None, description="Filter by country; repeatable"),
     cfg: Settings = Depends(get_settings),
+    pipeline: XMLPipelineService = Depends(get_pipeline),
 ) -> Response:
     logger.info(
         "GET /export/pdf — source=%s start=%s end=%s min_mag=%s alerts=%s countries=%s",
@@ -182,16 +175,13 @@ def export_pdf(
         countries,
     )
 
-    # Fetch events via the XML pipeline service. Support BOTH by merging sources.
-    pipeline = XMLPipelineService()
     events: list = []
     if source == "BOTH":
-        events.extend(pipeline.get_earthquakes("USGS", start_date, end_date, min_magnitude))
-        events.extend(pipeline.get_earthquakes("GDACS", start_date, end_date, min_magnitude))
+        events.extend(await pipeline.get_earthquakes("USGS", start_date, end_date, min_magnitude))
+        events.extend(await pipeline.get_earthquakes("GDACS", start_date, end_date, min_magnitude))
     else:
-        events = pipeline.get_earthquakes(source, start_date, end_date, min_magnitude)
+        events = await pipeline.get_earthquakes(source, start_date, end_date, min_magnitude)
 
-    # Build filters dict for the PDF generator
     filters = {
         "source": source,
         "start_date": start_date,
@@ -201,7 +191,6 @@ def export_pdf(
         "countries": countries or [],
     }
 
-    # Generate PDF bytes
     pdf_bytes = generate_situation_report(events, filters, datetime.now(timezone.utc))
 
     headers = {"Content-Disposition": "attachment; filename=Situation_Report.pdf"}

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -8,16 +8,17 @@ override any dependency via app.dependency_overrides.
 
 Usage in a router:
     from fastapi import Depends
-    from app.core.dependencies import get_settings
+    from app.core.dependencies import get_settings, get_pipeline
 
     @router.get("/example")
-    def example(cfg: Settings = Depends(get_settings)):
-        return {"env": cfg.ENV}
+    async def example(pipeline = Depends(get_pipeline)):
+        events = await pipeline.get_earthquakes()
 """
 
 from __future__ import annotations
 
 from app.core.config import Settings, settings
+from app.services.xml_pipeline import XMLPipelineService, get_compiled_xslt
 
 
 def get_settings() -> Settings:
@@ -27,3 +28,12 @@ def get_settings() -> Settings:
     singleton directly makes it trivial to swap out settings in tests.
     """
     return settings
+
+
+def get_pipeline() -> XMLPipelineService:
+    """Return an XMLPipelineService wired to the pre-compiled XSLT transforms.
+
+    The compiled_xslt dict is populated once during the app lifespan startup
+    and shared across every request for the lifetime of the process.
+    """
+    return XMLPipelineService(compiled_xslt=get_compiled_xslt())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.core.logging import configure_logging
 from app.core.rate_limit import RateLimitMiddleware
 from app.api.v1 import router as api_v1_router
 from app.api.health import router as health_router
+from app.services.xml_pipeline import compile_xslt_stylesheets
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -45,6 +46,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
         "Global Earthquake Monitor API starting — environment=%s",
         settings.ENV,
     )
+    compile_xslt_stylesheets(settings.XSLT_DIR)
+    logger.info("XSLT stylesheets compiled and cached for process lifetime.")
     yield
     logger.info("Global Earthquake Monitor API shutting down.")
 

--- a/backend/app/services/xml_pipeline.py
+++ b/backend/app/services/xml_pipeline.py
@@ -5,16 +5,25 @@ This service implements the authoritative intermediate XML representation
 required by the project architecture. It fetches raw QuakeML/RSS, applies
 XSLT transformations using lxml, and produces canonical XML before
 serializing to JSON.
+
+Performance optimisations
+-------------------------
+- XSLT stylesheets are compiled once at startup and reused across requests.
+- Upstream HTTP calls use httpx.AsyncClient (non-blocking I/O).
+- Fetched XML is held in a TTL cache so repeated requests within the
+  configured window are served from memory.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List
 
-import requests
+import httpx
+from cachetools import TTLCache
 from lxml import etree
 from app.core.config import settings
 from app.schemas.earthquakes import EarthquakeEvent
@@ -57,55 +66,128 @@ def _extract_country(place: str) -> str:
     return last
 
 
+# ---------------------------------------------------------------------------
+# Compiled XSLT cache (singleton, loaded once per process)
+# ---------------------------------------------------------------------------
+
+_compiled_xslt: dict[str, etree.XSLT] = {}
+
+
+def compile_xslt_stylesheets(xslt_dir: str = settings.XSLT_DIR) -> dict[str, etree.XSLT]:
+    """Parse and compile every known XSLT stylesheet exactly once.
+
+    Called during application startup via the FastAPI lifespan hook.
+    The returned dict is stored at module level and reused for the
+    lifetime of the process.
+    """
+    global _compiled_xslt  # noqa: PLW0603
+    xslt_path = Path(xslt_dir)
+
+    for provider, filename in (("USGS", "usgs_to_canonical.xsl"), ("GDACS", "gdacs_to_canonical.xsl")):
+        path = xslt_path / filename
+        if not path.exists():
+            logger.warning("XSLT stylesheet not found, skipping: %s", path)
+            continue
+        xslt_doc = etree.parse(str(path))
+        _compiled_xslt[provider] = etree.XSLT(xslt_doc)
+        logger.info("Compiled XSLT stylesheet: %s", filename)
+
+    return _compiled_xslt
+
+
+def get_compiled_xslt() -> dict[str, etree.XSLT]:
+    """Return the pre-compiled XSLT transforms (for use with Depends()).
+
+    Lazily compiles on first access if the lifespan hook hasn't run yet
+    (e.g. during tests that create a TestClient without entering the
+    context manager).
+    """
+    if not _compiled_xslt:
+        compile_xslt_stylesheets()
+    return _compiled_xslt
+
+
+# ---------------------------------------------------------------------------
+# In-memory TTL cache for upstream XML responses
+# ---------------------------------------------------------------------------
+
+_xml_cache: TTLCache[str, str] = TTLCache(
+    maxsize=32,
+    ttl=settings.CACHE_TTL_SECONDS,
+)
+
+
+def _cache_key(source: str, params: dict) -> str:
+    """Build a stable cache key from the source and query params."""
+    stable = sorted((k, str(v)) for k, v in params.items() if v is not None)
+    raw = f"{source}:{stable}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Pipeline service
+# ---------------------------------------------------------------------------
+
+
 class XMLPipelineService:
     """End-to-end XML data pipeline: Raw -> XSLT -> Canonical -> JSON."""
 
-    def __init__(self, xslt_dir: str = settings.XSLT_DIR, cache_dir: str = settings.CACHE_DIR):
+    def __init__(
+        self,
+        xslt_dir: str = settings.XSLT_DIR,
+        cache_dir: str = settings.CACHE_DIR,
+        compiled_xslt: dict[str, etree.XSLT] | None = None,
+    ):
         self.xslt_dir = Path(xslt_dir)
         self.cache_dir = Path(cache_dir)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         (self.cache_dir / "canonical").mkdir(exist_ok=True)
+        self._compiled_xslt = compiled_xslt or _compiled_xslt
 
-    def fetch_raw_xml(self, source: str, params: dict) -> str:
-        """Fetch raw XML/QuakeML from the upstream provider."""
-        url = settings.USGS_API_BASE if source == "USGS" else settings.GDACS_RSS_URL
-        
-        # USGS needs query params for XML format
+    async def fetch_raw_xml(self, source: str, params: dict) -> str:
+        """Fetch raw XML/QuakeML from the upstream provider (async, cached)."""
+        url = str(settings.USGS_API_BASE) if source == "USGS" else str(settings.GDACS_RSS_URL)
+
         if source == "USGS":
             params["format"] = "xml"
-        
-        logger.info("Fetching raw %s XML from %s", source, url)
-        response = requests.get(str(url), params=params, timeout=30)
-        response.raise_for_status()
-        return response.text
+
+        key = _cache_key(source, params)
+        cached = _xml_cache.get(key)
+        if cached is not None:
+            logger.info("Cache HIT for %s (key=%s…)", source, key[:12])
+            return cached
+
+        logger.info("Cache MISS — fetching raw %s XML from %s", source, url)
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(url, params=params)
+            response.raise_for_status()
+
+        text = response.text
+        _xml_cache[key] = text
+        return text
 
     def apply_xslt(self, raw_xml: str, provider: str) -> str:
-        """Transform raw XML into canonical XML using lxml.etree.XSLT."""
-        stylesheet_name = "usgs_to_canonical.xsl" if provider == "USGS" else "gdacs_to_canonical.xsl"
-        stylesheet_path = self.xslt_dir / stylesheet_name
+        """Transform raw XML into canonical XML using a pre-compiled XSLT."""
+        transform = self._compiled_xslt.get(provider)
+        if transform is None:
+            raise FileNotFoundError(
+                f"No compiled XSLT for provider '{provider}'. "
+                f"Available: {list(self._compiled_xslt.keys())}"
+            )
 
-        if not stylesheet_path.exists():
-            raise FileNotFoundError(f"XSLT stylesheet not found: {stylesheet_path}")
+        logger.info("Applying pre-compiled XSLT transformation for %s", provider)
 
-        logger.info("Applying XSLT transformation: %s", stylesheet_name)
-        
-        # Load XML and XSLT
-        # We use recover=True to handle minor XML inconsistencies in upstream feeds
         parser = etree.XMLParser(recover=True, encoding="utf-8")
         try:
             dom = etree.fromstring(raw_xml.encode("utf-8"), parser=parser)
-            xslt_doc = etree.parse(str(stylesheet_path))
-            transform = etree.XSLT(xslt_doc)
-            
-            # Execute transformation
             new_dom = transform(dom)
             canonical_xml = str(new_dom)
-            
+
             # Persist canonical XML to cache for audit/grading visibility
             cache_file = self.cache_dir / "canonical" / f"{provider.lower()}_latest.xml"
             with open(cache_file, "w", encoding="utf-8") as f:
                 f.write(canonical_xml)
-            
+
             return canonical_xml
         except Exception as e:
             logger.error("XSLT Transformation failed for %s: %s", provider, e)
@@ -116,7 +198,7 @@ class XMLPipelineService:
         try:
             root = etree.fromstring(canonical_xml.encode("utf-8"))
             events = []
-            
+
             for event_node in root.xpath("//event"):
                 # Helper to get text safely
                 def get_val(xpath, default=""):
@@ -126,14 +208,12 @@ class XMLPipelineService:
                 # Parse and normalize fields
                 raw_time = get_val("main_time")
                 try:
-                    # Generic ISO-ish parse for main_time
                     main_time = datetime.fromisoformat(raw_time.replace("Z", "+00:00"))
                 except (ValueError, TypeError):
-                    # Fallback for RSS dates (simplified)
                     main_time = datetime.now(timezone.utc)
 
                 mag = float(get_val("magnitude", "0.0"))
-                
+
                 # Derive alert level if placeholder
                 alert = get_val("alert_level", "Unknown")
                 if alert == "Unknown" or not alert:
@@ -172,29 +252,29 @@ class XMLPipelineService:
                     severity_text=get_val("severity_text") or None,
                     population_text=get_val("population_text") or None
                 ))
-            
+
             return events
         except Exception as e:
             logger.error("Failed to parse canonical XML: %s", e)
             return []
 
-    def get_earthquakes(
-        self, 
-        source: str = "USGS", 
-        start_date: str | None = None, 
-        end_date: str | None = None, 
+    async def get_earthquakes(
+        self,
+        source: str = "USGS",
+        start_date: str | None = None,
+        end_date: str | None = None,
         min_mag: float = 2.5
     ) -> List[EarthquakeEvent]:
-        """Fetch, transform, and return earthquake events."""
+        """Fetch, transform, and return earthquake events (async)."""
         params = {
             "starttime": start_date,
             "endtime": end_date,
             "minmagnitude": min_mag,
             "orderby": "time"
         }
-        
+
         try:
-            raw_xml = self.fetch_raw_xml(source, params)
+            raw_xml = await self.fetch_raw_xml(source, params)
             canonical_xml = self.apply_xslt(raw_xml, source)
             return self.parse_canonical_xml(canonical_xml)
         except Exception as e:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,8 +25,9 @@ python-dotenv>=1.0,<2.0
 # Data processing
 # ---------------------------------------------------------------------------
 pandas>=2.0,<3.0
-requests>=2.31,<3.0
-lxml>=5.0,<6.0          # XSLT pipeline: lxml.etree.XSLT
+httpx>=0.27,<1.0          # async HTTP client for upstream XML fetches
+cachetools>=5.3,<6.0      # in-memory TTL cache for fetched XML
+lxml>=5.0,<6.0            # XSLT pipeline: lxml.etree.XSLT
 
 # ---------------------------------------------------------------------------
 # AI / Gemini

--- a/backend/tests/test_ai_chat.py
+++ b/backend/tests/test_ai_chat.py
@@ -20,12 +20,18 @@ def _make_client_with_settings(custom_settings):
     return TestClient(application, raise_server_exceptions=False)
 
 
+async def _mock_get_earthquakes_with_event(event):
+    """Return an async mock for get_earthquakes that yields a single event."""
+    async def _mock(self, *a, **kw):
+        return [event]
+    return _mock
+
+
 def test_chat_success_parses_actions(monkeypatch) -> None:
     """When Gemini returns actionable [[...]] tags they should be parsed."""
     from app.schemas.earthquakes import EarthquakeEvent
     from app.core.config import Settings
 
-    # Small sample event for context generation
     event = EarthquakeEvent(
         id="ev1",
         title="Test Quake",
@@ -46,13 +52,15 @@ def test_chat_success_parses_actions(monkeypatch) -> None:
         link="http://example",
     )
 
-    # Mock pipeline to return our single event
+    # Mock pipeline — must return a coroutine since get_earthquakes is async
+    async def mock_get_earthquakes(self, *a, **kw):
+        return [event]
+
     monkeypatch.setattr(
         "app.services.xml_pipeline.XMLPipelineService.get_earthquakes",
-        lambda self, *a, **kw: [event],
+        mock_get_earthquakes,
     )
 
-    # Mock the generative model to return a known response with tags
     class DummyResponse:
         def __init__(self, text: str):
             self.text = text
@@ -94,10 +102,12 @@ def test_chat_quota_exhaustion_returns_429(monkeypatch) -> None:
     """If all models raise quota errors the endpoint should return 429."""
     from app.core.config import Settings
 
-    # pipeline: return empty list
+    async def mock_get_earthquakes(self, *a, **kw):
+        return []
+
     monkeypatch.setattr(
         "app.services.xml_pipeline.XMLPipelineService.get_earthquakes",
-        lambda self, *a, **kw: [],
+        mock_get_earthquakes,
     )
 
     class FailModel:

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -63,10 +63,12 @@ def test_export_pdf_returns_pdf_and_headers(monkeypatch) -> None:
 
     dummy = _make_dummy_event()
 
-    # Patch XMLPipelineService.get_earthquakes to avoid network calls
+    async def mock_get_earthquakes(self, source, start_date, end_date, min_mag):
+        return [dummy]
+
     monkeypatch.setattr(
         "app.services.xml_pipeline.XMLPipelineService.get_earthquakes",
-        lambda self, source, start_date, end_date, min_mag: [dummy],
+        mock_get_earthquakes,
     )
 
     response = client.get("/api/v1/export/pdf")
@@ -76,16 +78,18 @@ def test_export_pdf_returns_pdf_and_headers(monkeypatch) -> None:
     cd = response.headers.get("content-disposition", "")
     assert "attachment" in cd
     assert "Situation_Report.pdf" in cd
-    # Basic sanity: PDF bytes should start with %PDF
     assert response.content.startswith(b"%PDF")
 
 
 def test_export_xml_returns_xml_and_headers(monkeypatch) -> None:
     client = TestClient(app)
 
+    async def mock_fetch_raw_xml(self, source, params):
+        return _CANONICAL_XML.decode("utf-8")
+
     monkeypatch.setattr(
         "app.services.xml_pipeline.XMLPipelineService.fetch_raw_xml",
-        lambda self, source, params: _CANONICAL_XML.decode("utf-8"),
+        mock_fetch_raw_xml,
     )
     monkeypatch.setattr(
         "app.services.xml_pipeline.XMLPipelineService.apply_xslt",
@@ -108,9 +112,12 @@ def test_export_csv_returns_csv_and_headers(monkeypatch) -> None:
 
     dummy = _make_dummy_event()
 
+    async def mock_get_earthquakes(self, source, start_date, end_date, min_mag):
+        return [dummy]
+
     monkeypatch.setattr(
         "app.services.xml_pipeline.XMLPipelineService.get_earthquakes",
-        lambda self, source, start_date, end_date, min_mag: [dummy],
+        mock_get_earthquakes,
     )
 
     response = client.get("/api/v1/export/csv")
@@ -121,7 +128,6 @@ def test_export_csv_returns_csv_and_headers(monkeypatch) -> None:
     cd = response.headers.get("content-disposition", "")
     assert "attachment" in cd
     assert "earthquakes.csv" in cd
-    # CSV must have a header row and at least one data row
     lines = response.content.decode("utf-8").splitlines()
     assert len(lines) >= 2
     assert "magnitude" in lines[0]


### PR DESCRIPTION
## Summary

Three high-priority backend performance fixes that eliminate the worst bottlenecks identified in the pipeline:

### 1. XSLT Singleton Pattern
- Compiled XSLT transforms are loaded **once** at app startup via the FastAPI lifespan hook
- Stored at module level and injected into route handlers via `Depends(get_pipeline)`
- Eliminates per-request stylesheet parsing and compilation (~100–500ms saved per request)
- Lazy fallback ensures tests work even without the lifespan context manager

### 2. Async HTTP (httpx)
- Replaced synchronous `requests.get()` with `httpx.AsyncClient` in `fetch_raw_xml()`
- Upstream XML fetches no longer block the Uvicorn event loop
- Enables proper concurrency — multiple users' requests can overlap during upstream I/O waits
- Removed `requests` from dependencies (no longer used anywhere)

### 3. In-Memory TTL Cache (cachetools)
- Fetched XML responses are cached in a `cachetools.TTLCache` (max 32 entries)
- Cache key is derived from source + query params (SHA-256 hash)
- Repeated requests within `CACHE_TTL_SECONDS` (default 600s) are served from memory
- Eliminates redundant upstream API calls — visible as `Cache HIT` / `Cache MISS` in logs

### Supporting changes
- All route handlers converted to `async` (`earthquakes`, `chat`, `export`)
- Pipeline injected via `Depends(get_pipeline)` instead of module-level or per-request instantiation
- `requirements.txt`: added `httpx`, `cachetools`; removed unused `requests`
- Test mocks updated to return coroutines for async method signatures
- **34/34 tests passing**

## Test plan
- [x] `pytest -v` — all 34 tests pass
- [x] `docker compose up --build backend` — verify startup logs show "XSLT stylesheets compiled"
- [x] Hit `/api/v1/earthquakes` twice rapidly — second call should log `Cache HIT`
- [x] Verify `/api/v1/export/xml` still returns canonical XSLT-transformed XML
- [x] Verify `/api/v1/chat` still returns AI responses with action parsing